### PR TITLE
Update Node.js version used for SonarQube scans

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
 		stage('Run SonarQube Scan') {
 			steps{
 				withSonarQubeEnv('cessda-sonar') {
-					nodejs('node-12') {
+					nodejs('node-14') {
 						sh "${scannerHome}/bin/sonar-scanner"
 					}
 				}


### PR DESCRIPTION
This is to fix a build issue caused by using an out of date version of Node