### PR TITLE
fix links to deprecated bitbucket repos

### DIFF
--- a/CONTRIBUTING_template.md
+++ b/CONTRIBUTING_template.md
@@ -6,7 +6,7 @@ Please note that we welcome all forms of user feedback and are generally open to
 but please read this document carefully before proceeding.
 
 General information on contributing to CESSDA Open Source Software can also be found in the
-[Contribution Guidelines](https://bitbucket.org/cessda/cessda.guidelines.public/src/master/CONTRIBUTING.md).
+[Contribution Guidelines](https://github.com/cessda/cessda.guidelines.public/blob/main/CONTRIBUTING.md).
 
 ## User feedback
 

--- a/software/documentation-guidelines/documentation-tooling.md
+++ b/software/documentation-guidelines/documentation-tooling.md
@@ -14,7 +14,7 @@ A custom [CESSDA theme](https://rubygems.org/gems/jekyll-cessda-docs) has been d
 As such, the documentation for [Just the docs](https://just-the-docs.github.io/just-the-docs/) can be followed,
 but the design should not be touched.
 
-The repository for the [CESSDA Technical Guidelines](https://bitbucket.org/cessda/cessda.guidelines.public)
+The repository for the [CESSDA Technical Guidelines](https://github.com/cessda/cessda.guidelines.public)
 should be consulted for implementation details.
 The repository's `README` also lists a number of recommendations on language.
 

--- a/software/documentation-guidelines/index.md
+++ b/software/documentation-guidelines/index.md
@@ -138,7 +138,7 @@ Jenkins has been chosen as the {% include glossary.html entry="CI" text="CI" %} 
 
 The Bitbucket {% include glossary.html entry="SCM" text="SCM" %} system has been mandated,
 and each product has its own project (containing one or more repositories) within the
-[CESSDA Research Infrastructure project space](https://bitbucket.org/cessda/workspace/projects/).
+[CESSDA Research Infrastructure project space](https://github.com/cessda).
 Each repository is linked to the {% include glossary.html entry="CIT" text="CIT" %}
 environment via a Jenkinsfile and corresponding Jenkins jobs,
 so that software quality assurance takes place throughout the development phase.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,4 +6,4 @@ sonar.sourceEncoding=UTF-8
 
 # Helpful links in the SonarQube interface
 sonar.links.ci=https://jenkins.cessda.eu/
-sonar.links.scm=https://bitbucket.org/cessda/cessda.guidelines.public/
+sonar.links.scm=https://github.com/cessda/cessda.guidelines.public/

--- a/technical-infrastructure/gcp-repository-standard-contents.md
+++ b/technical-infrastructure/gcp-repository-standard-contents.md
@@ -16,7 +16,7 @@ See [Naming Conventions]({% link technical-infrastructure/naming-conventions.md 
 
 Unless otherwise stated, see [Software requirements]({% link software/requirements.md %})
 for links to examples of good practice for the following files,
-and/or the [CDC Indexer](https://bitbucket.org/cessda/cessda.cdc.osmh-indexer.cmm/src/) repository.
+and/or the [CDC Indexer](https://github.com/cessda/cessda.cdc.osmh-indexer.cmm) repository.
 
 ### .gitignore
 

--- a/technical-infrastructure/technical-infrastructure-details.md
+++ b/technical-infrastructure/technical-infrastructure-details.md
@@ -15,7 +15,7 @@ See [Naming Conventions]({% link technical-infrastructure/naming-conventions.md 
 The diagram shows a general overview of the GCP projects,
 Jenkins CI/CD toolchain and Bitbucket code repositories and how they are integrated within the deployment pipeline.
 
-* This designs explains the version control systems in [Bitbucket](https://bitbucket.org/cessda/)
+* This designs explains the version control systems in [Github](https://github.com/cessda/)
 
 This system allows developers to keep track of the changes in CESSDA software development projects,
 and enable them to collaborate on those projects or tools.


### PR DESCRIPTION
This PR fixes some deprecated links I found (and stumbled upon) at https://docs.tech.cessda.eu/ , like

- https://bitbucket.org/cessda/cessda.guidelines.public/src/master/CONTRIBUTING.md --> https://github.com/cessda/cessda.guidelines.public/blob/main/CONTRIBUTING.md
- https://bitbucket.org/cessda/cessda.guidelines.public --> https://github.com/cessda/cessda.guidelines.public
- https://bitbucket.org/cessda/workspace/projects/ --> https://github.com/cessda
- https://bitbucket.org/cessda/cessda.cdc.osmh-indexer.cmm/src/ --> https://github.com/cessda/cessda.cdc.osmh-indexer.cmm