### PR TITLE
Make GitHub spelling consistent

### DIFF
--- a/document-navigation-structure.md
+++ b/document-navigation-structure.md
@@ -53,7 +53,7 @@ The indentation is intended to indicate major sections, subsections and sub-subs
     (3602) Adding the Deployment Jenkinsfile
   (365) Building with Docker
   (370) Platform Team Responsibilities
-    (3701) Create a Github Repository
+    (3701) Create a GitHub Repository
     (3702) Standard Git Repository Contents
     (3703) Create a New Jenkins Job
     (3704) Creating a Test Suite

--- a/forms/repo-request.md
+++ b/forms/repo-request.md
@@ -24,7 +24,7 @@ Depending on your role, you may be interested in:
 
 ## Purpose
 
-Use this form to request a new [Git repository, hosted on Github](https://github.com/cessda/).
+Use this form to request a new [Git repository, hosted on GitHub](https://github.com/cessda/).
 
 <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdP7oOyLWbRKsEtPszEY_NKyQ6Db32jmoku5IatlIzmeP6LVQ/viewform?embedded=true"
   width="640" height="875" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>

--- a/software/documentation-guidelines/index.md
+++ b/software/documentation-guidelines/index.md
@@ -30,7 +30,7 @@ Strings in general should be externalised.
 In particular, messages intended to be displayed to the User via the GUI,
 console or other output mechanism should not be present in source code as this inhibits language localisation.
 Also source code should be free of configuration information in order to comply with
-12 factor app principle number 3 [Config - Store config in the environment](https://12factor.net/config)).
+12 factor app principle number 3 ([Config - Store config in the environment](https://12factor.net/config)).
 Configuration information should be made available at run time via environment variables.
 
 ## Environment-specific information
@@ -127,7 +127,7 @@ Jenkins has been chosen as the {% include glossary.html entry="CI" text="CI" %} 
 - Familiarity: experience of configuration and/or use amongst several CESSDA SPs
 
 - Features: provides tried and tested {% include glossary.html entry="CI" text="CI" %};
-    links with Github and other {% include glossary.html entry="SCM" text="SCM" %} systems;
+    links with GitHub and other {% include glossary.html entry="SCM" text="SCM" %} systems;
     hundreds of free plugins available;
     can build and deploy containers
 
@@ -136,14 +136,14 @@ Jenkins has been chosen as the {% include glossary.html entry="CI" text="CI" %} 
 
 ## Source code management
 
-The Github {% include glossary.html entry="SCM" text="SCM" %} system has been mandated,
+The GitHub {% include glossary.html entry="SCM" text="SCM" %} system has been mandated,
 and each product has its own project (containing one or more repositories) within the
 [CESSDA Research Infrastructure project space](https://github.com/cessda).
 Each repository is linked to the {% include glossary.html entry="CIT" text="CIT" %}
 environment via a Jenkinsfile and corresponding Jenkins jobs,
 so that software quality assurance takes place throughout the development phase.
 
-The choice of Github was based on a combination of standards, familiarity, features and transferability:
+The choice of GitHub was based on a combination of standards, familiarity, features and transferability:
 
 - Standards: a de facto standard for {% include glossary.html entry="SCM" text="SCM" %}; supports Git and Mercurial repositories;
 

--- a/software/index.md
+++ b/software/index.md
@@ -6,7 +6,7 @@ nav_order: 100
 
 # {{ page.title }}
 
-Development of CESSDA tools and services is carried out using CESSDA-owned git-repositories on Github.
+Development of CESSDA tools and services is carried out using CESSDA-owned git-repositories on GitHub.
 
 If the code is developed publicly elsewhere, mirroring with clear pointers to the upstream are used.
 

--- a/software/interoperability.md
+++ b/software/interoperability.md
@@ -11,15 +11,12 @@ CESSDA's Infrastructure is based on Docker Containers orchestrated by Kubernetes
 Thus any CESSDA service must follow the following design principles, building upon the [Twelve-Factor App](https://12factor.net/):
 
 * Applications must be capsuled in individual Docker containers exposing ports.
-
 * Configuration must be read from the environment on startup.
-
 * Rest APIs
   * Use API versioning.
   * Provide [OpenAPI](https://www.openapis.org/) documentation.
   * Implement `X-Request-ID` headers.
-
-* See [logging guidelines]({% link software/logging-guidelines.md %}) for further information re logging container output.
+* See [logging guidelines]({% link software/logging-guidelines.md %}) for further information regarding logging container output.
 
 The software architecture is intended to meet CESSDA’s five common interoperability characteristics as follows.
 In each case, CESSDA’s objective for the characteristic is stated, followed by the approach used to achieve it.

--- a/software/issue-tracking.md
+++ b/software/issue-tracking.md
@@ -6,7 +6,7 @@ nav_order: 150
 
 # {{ page.title }}
 
-We use Github Issue Tracking for projects that need an issue tracker for Service Providers and CESSDA MO use.
+We use GitHub Issue Tracking for projects that need an issue tracker for Service Providers and CESSDA MO use.
 Where a product is made up of many components, only one of the repositories will have the issue tracker enabled, to avoid confusion.
 
 ## Workflow

--- a/software/logging-guidelines.md
+++ b/software/logging-guidelines.md
@@ -72,7 +72,7 @@ public class ConsumerScheduler {
 The default log level for CESSDA is **WARN**.
 
 This communicates to the Platform support team that this message needs some kind of attention.
-In such a scenario, an issue will be created in the Github issue tracker for resolution.
+In such a scenario, an issue will be created in the GitHub issue tracker for resolution.
 Below is the example from the CDC harvester component:
 
 ```java

--- a/technical-infrastructure/continuous-integration-and-deployment/platform-processes/github-new-repo.md
+++ b/technical-infrastructure/continuous-integration-and-deployment/platform-processes/github-new-repo.md
@@ -1,5 +1,5 @@
 ---
-title: Create a Github Repository
+title: Create a GitHub Repository
 parent: Platform Processes
 grand_parent: Continuous Integration and Deployment
 published: true
@@ -14,9 +14,9 @@ See [Naming Conventions]({% link technical-infrastructure/naming-conventions.md 
 
 ## Instructions for members of the Platform Team
 
-Before doing anything, you must **log in to Github using an account that has administrative privileges**.
+Before doing anything, you must **log in to GitHub using an account that has administrative privileges**.
 
-### First decide which Github organisation to put the repository in
+### First decide which GitHub organisation to put the repository in
 
 * cessda - use for public repositories (the vast majority of repositories are public)
 

--- a/technical-infrastructure/continuous-integration-and-deployment/platform-processes/index.md
+++ b/technical-infrastructure/continuous-integration-and-deployment/platform-processes/index.md
@@ -20,7 +20,7 @@ See [Updating CI Tools]({% link technical-infrastructure/continuous-integration-
 ## Create repositories
 
 - {% include glossary.html entry="(application code)" text="application code" %}.
-        See ['Create a Github Repository'](github-new-repo.html) for details.
+        See ['Create a GitHub Repository'](github-new-repo.html) for details.
 
 - Deployment, via Helm.
         See CDC Deployment (<https://github.com/cessda/cessda.cdc.deploy/src/master/>) repository for a working example.

--- a/technical-infrastructure/deploying-core-products.md
+++ b/technical-infrastructure/deploying-core-products.md
@@ -29,14 +29,14 @@ See the 'Product Coordination' document for definition of roles.
 
 ### Technical Contact
 
-Creates an issue in the tool-specific issue tracker in Github,
+Creates an issue in the tool-specific issue tracker in GitHub,
 changes the status to OPEN and assigns it to the Content Contact for the tool.
 
 - Recommend pattern for issue title is *'Release version X.Y.Z of \<tool name\> to production'*
 
 - For traceability, the version number of the release **must** be included in the issue.
 
-- The relevant repositories must be [tagged](https://confluence.atlassian.com/Github/repository-tags-321860179.html)
+- The relevant repositories must be [tagged](https://confluence.atlassian.com/GitHub/repository-tags-321860179.html)
     with the release version number.
 
 - For verification purposes, the [changelog](https://keepachangelog.com/en/1.0.0/) **must** be referenced.

--- a/technical-infrastructure/gcp-repository-standard-contents.md
+++ b/technical-infrastructure/gcp-repository-standard-contents.md
@@ -18,13 +18,13 @@ Unless otherwise stated, see [Software requirements]({% link software/requiremen
 for links to examples of good practice for the following files,
 and/or the [CDC Indexer](https://github.com/cessda/cessda.cdc.osmh-indexer.cmm) repository.
 
-### .gitignore
+### `.gitignore`
 
 The `.gitignore` should be populated with file that are not needed in the repository, such as log files, databases, executable,
 results from compilation, reports from test frameworks, cached files etc.
 
 Here are several [`.gitignore` templates](https://github.com/github/gitignore) hosted on GitHub.
-The `.gitignore` templates should be customised for any application specific paths, such as secrets and build directories.
+The `.gitignore` templates should be customised by adding any application specific paths, such as secrets and build directories.
 
 ### CHANGELOG.md
 

--- a/technical-infrastructure/index.md
+++ b/technical-infrastructure/index.md
@@ -44,7 +44,7 @@ a step by step explanation of the build and deployment processes.
 Actors in order to get a new release deployed.
 
 [Technical Infrastructure Details]({% link technical-infrastructure/technical-infrastructure-details.md %}) - shows a general overview
-of the GCP projects, Jenkins CI/CD toolchain and Github code repositories and how they are
+of the GCP projects, Jenkins CI/CD toolchain and GitHub code repositories and how they are
 integrated within the deployment pipeline.
 
 [Jenkinsfile Template]({% link technical-infrastructure/template-jenkinsfile.md %}) - This shows the general form of a Jenkinsfile used

--- a/technical-infrastructure/technical-infrastructure-details.md
+++ b/technical-infrastructure/technical-infrastructure-details.md
@@ -13,9 +13,9 @@ See [Naming Conventions]({% link technical-infrastructure/naming-conventions.md 
 ## Overview
 
 The diagram shows a general overview of the GCP projects,
-Jenkins CI/CD toolchain and Github code repositories and how they are integrated within the deployment pipeline.
+Jenkins CI/CD toolchain and GitHub code repositories and how they are integrated within the deployment pipeline.
 
-* This designs explains the version control systems in [Github](https://github.com/cessda/)
+* This designs explains the version control systems in [GitHub](https://github.com/cessda/)
 
 This system allows developers to keep track of the changes in CESSDA software development projects,
 and enable them to collaborate on those projects or tools.


### PR DESCRIPTION
There are many instances where GitHub is spelled as Github. This PR corrects these occurences.