### PR TITLE
Use the Git commit id as the source of the documentation's version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,11 @@ pipeline {
 			steps {
 				sh 'bundle exec rake htmlproofer'
 			}
+			post {
+				success {
+					archiveArtifacts '_site/**/*'
+				}
+			}
 		}
 		stage('Run SonarQube Scan') {
 			steps{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
 				}
 			}
 			environment {
-				JEKYLL_ENV = "${GIT_COMMIT.substring(0,5)}"
+				JEKYLL_ENV = "${GIT_COMMIT}"
 			}
 			steps {
 				sh 'jekyll build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
 	environment {
 		productName = 'guidelines'
 		componentName = 'public'
-		imageTag = "${docker_repo}/${productName}-${componentName}:${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
+		imageTag = "${docker_repo}/${productName}-${componentName}:${GIT_COMMIT}"
 		scannerHome = tool 'sonar-scanner'
 	}
 
@@ -46,6 +46,9 @@ pipeline {
 					filename 'jekyll.Dockerfile'
 					reuseNode true
 				}
+			}
+			environment {
+				JEKYLL_ENV = "${GIT_COMMIT.substring(0,5)}"
 			}
 			steps {
 				sh 'jekyll build'
@@ -79,19 +82,18 @@ pipeline {
 			steps {
 				sh "docker build -t ${imageTag} -f nginx.Dockerfile ."
 			}
-			when { branch 'main' }
 		}
 		stage('Push Docker Container') {
 			steps {
 				sh "gcloud auth configure-docker"
 				sh "docker push ${imageTag}"
-				sh "gcloud container images add-tag ${imageTag} ${docker_repo}/${productName}-${componentName}:${env.BRANCH_NAME}-latest"
+				sh "gcloud container images add-tag ${imageTag} ${docker_repo}/${productName}-${componentName}:latest"
 			}
 			when { branch 'main' }
 		}
 		stage('Deploy Guidelines') {
 			steps {
-				build job: 'cessda.guidelines.deploy/main', parameters: [string(name: 'imageTag', value: "${env.BRANCH_NAME}-${env.BUILD_NUMBER}")]
+				build job: 'cessda.guidelines.deploy/main', parameters: [string(name: 'imageTag', value: "${GIT_COMMIT}")]
 			}
 			when { branch 'main' }
 		}

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ Changes since previous version:
 {% if jekyll.environment == "development" %}
 **This is a development build!**
 {% else %}
-Built from commit [{{ jekyll.environment | truncate: 6, "" }}](https://github.com/cessda/cessda.guidelines.public/commit/{{jekyll.environment}}) on {{ site.time | date: "%d %B %Y" }}.
+Built from commit [{{ jekyll.environment | truncate: 7, "" }}](https://github.com/cessda/cessda.guidelines.public/commit/{{jekyll.environment}}) on {{ site.time | date: "%d %B %Y" }}.
 {% endif %}
 
 ![CC-BY-4.0](images/cc-by.svg "CC-BY-4.0")

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ Changes since previous version:
 {% if jekyll.environment == "development" %}
 **This is a development build!**
 {% else %}
-Built from commit [{{ jekyll.environment | truncate: 6, "" }}](https://github.com/cessda/cessda.guidelines.public/commit/{{jekyll.environment}}), built on {{ site.time | date: "%d %B %Y" }}.
+Built from commit [{{ jekyll.environment | truncate: 6, "" }}](https://github.com/cessda/cessda.guidelines.public/commit/{{jekyll.environment}}) on {{ site.time | date: "%d %B %Y" }}.
 {% endif %}
 
 ![CC-BY-4.0](images/cc-by.svg "CC-BY-4.0")

--- a/index.md
+++ b/index.md
@@ -19,12 +19,7 @@ This includes information about the underlying architectural principles.
 The [Software Maturity Levels]({% link sml/index.md %})
 that form the basis for CESSDA Quality Assurance are also included.
 
-Changes since previous version:
-
-* Updated [Metadata Handling in CESSDA]({% link metadata/index.md %}) section
-* Added Feedback Mechanism for the Guideline
-* Updated [Online Forms]({% link forms/index.md %}) section
-* Updated [Technical Infrastructure]({% link technical-infrastructure/index.md %}) section
+Recent changes to the guidelines can be found at [the detailed changelog](https://github.com/cessda/cessda.guidelines.public/commits/main/{{jekyll.environment}}).
 
 {% if jekyll.environment == "development" %}
 **This is a development build!**

--- a/index.md
+++ b/index.md
@@ -26,14 +26,10 @@ Changes since previous version:
 * Updated [Online Forms]({% link forms/index.md %}) section
 * Updated [Technical Infrastructure]({% link technical-infrastructure/index.md %}) section
 
-{% if site.development_status %}
-  {% if site.jenkins_job %}
-  Built by Jenkins: [{{site.jenkins_job}}]({{site.jenkins_job}})
-  {% else %}
-  **This is a development build!**
-  {% endif %}
+{% if jekyll.environment == "development" %}
+**This is a development build!**
 {% else %}
-This is version {{ site.version }}, released on {{ site.time | date: "%d %B %Y" }}.
+This is version {{ jekyll.environment }}, built on {{ site.time | date: "%d %B %Y" }}.
 {% endif %}
 
 ![CC-BY-4.0](images/cc-by.svg "CC-BY-4.0")

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ Changes since previous version:
 {% if jekyll.environment == "development" %}
 **This is a development build!**
 {% else %}
-This is version {{ jekyll.environment }}, built on {{ site.time | date: "%d %B %Y" }}.
+Built from commit [{{ jekyll.environment }}](https://github.com/cessda/cessda.guidelines.public/commit/{{ jekyll.environment | truncate: 6, "" }}), built on {{ site.time | date: "%d %B %Y" }}.
 {% endif %}
 
 ![CC-BY-4.0](images/cc-by.svg "CC-BY-4.0")

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ Changes since previous version:
 {% if jekyll.environment == "development" %}
 **This is a development build!**
 {% else %}
-Built from commit [{{ jekyll.environment }}](https://github.com/cessda/cessda.guidelines.public/commit/{{ jekyll.environment | truncate: 6, "" }}), built on {{ site.time | date: "%d %B %Y" }}.
+Built from commit [{{ jekyll.environment | truncate: 6, "" }}](https://github.com/cessda/cessda.guidelines.public/commit/{{jekyll.environment}}), built on {{ site.time | date: "%d %B %Y" }}.
 {% endif %}
 
 ![CC-BY-4.0](images/cc-by.svg "CC-BY-4.0")

--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ This includes information about the underlying architectural principles.
 The [Software Maturity Levels]({% link sml/index.md %})
 that form the basis for CESSDA Quality Assurance are also included.
 
-Recent changes to the guidelines can be found at [the detailed changelog](https://github.com/cessda/cessda.guidelines.public/commits/main/{{jekyll.environment}}).
+Recent changes to the guidelines can be found at [the detailed changelog](https://github.com/cessda/cessda.guidelines.public/commits/{{jekyll.environment}}).
 
 {% if jekyll.environment == "development" %}
 **This is a development build!**


### PR DESCRIPTION
This commit replaces the semantic versioning system with Git commits. Semantic versioning doesn't make much sense for documentation, as documentation exposes no APIs. Using a Git commit makes tracing versioning easier. This is necessary to implement continuous deployment.

A link to the commit that built the documentation has been added to the index. The changelog has been converted to use GitHub's commit history from the built commit.

This closes #149.