### PR TITLE
Use the internet archives for links to the EOSC-Hub TRL definition

### DIFF
--- a/services/requirements.md
+++ b/services/requirements.md
@@ -10,7 +10,7 @@ CESSDA requires its tools and services to be of sufficient quality for sustainab
 
 The quality and acceptability criteria for CESSDA tools and services are defined by the
 [CESSDA Software Maturity Levels]({% link sml/index.md %})
-and the [EOSC Technology Readiness Levels (TRL)](https://wiki.eosc-hub.eu/display/EOSC/Service+Maturity+Classification).
+and the [EOSC Technology Readiness Levels (TRL)](https://web.archive.org/web/20220121063627/https://wiki.eosc-hub.eu/display/EOSC/Service+Maturity+Classification).
 
 For a software system to be operated by CESSDA as a **TRL-8 production service**, the following criteria must be met:
 

--- a/sml/index.md
+++ b/sml/index.md
@@ -80,7 +80,7 @@ production-ready by them. Interestingly, both RRLs and TRLs were devised
 by and are widely used by NASA.
 
 [2]: https://fitsm.itemo.org/fitsm
-[3]: https://wiki.eosc-hub.eu/display/EOSC/Service+Maturity+Classification
+[3]: https://web.archive.org/web/20220121063627/https://wiki.eosc-hub.eu/display/EOSC/Service+Maturity+Classification
 [4]: https://ec.europa.eu/research/participants/data/ref/h2020/other/wp/2016-2017/annexes/h2020-wp1617-annex-ga_en.pdf
 
 Table 1 shows the correspondence between the various levels in the RRL

--- a/sml/sml-references.md
+++ b/sml/sml-references.md
@@ -10,7 +10,7 @@ nav_order: 492
 
 [2] The FitSM Standard, <https://fitsm.itemo.org/fitsm>
 
-[3] EOSC Technology Readiness Levels (TRLs), <https://wiki.eosc-hub.eu/display/EOSC/Service+Maturity+Classification>
+[3] EOSC Technology Readiness Levels (TRLs), <https://web.archive.org/web/20220121063627/https://wiki.eosc-hub.eu/display/EOSC/Service+Maturity+Classification>
 
 [4] HORIZON 2020 WORK PROGRAMME 2016-- 2017, 20. General Annexes, G. EC Technology Readiness Levels,
 <https://ec.europa.eu/research/participants/data/ref/h2020/other/wp/2016-2017/annexes/h2020-wp1617-annex-ga_en.pdf>


### PR DESCRIPTION
The EOSC-Hub wiki is now offline, so all links need to be changed.

This closes #155